### PR TITLE
fix: remove IsMultiDialectView from aws glue table input

### DIFF
--- a/databricks_aws_utils/delta_table.py
+++ b/databricks_aws_utils/delta_table.py
@@ -82,6 +82,7 @@ class DeltaTableUtils(DatabrickAWSUtils):
         del table['CreatedBy']
         del table['VersionId']
         del table['CatalogId']
+        del table['IsMultiDialectView']
 
         params = table['Parameters'] or {}
         params['table_type'] = 'DELTA'


### PR DESCRIPTION
#### Description

This PR removes the `IsMultiDialectView` from the AWS Glue table input.
